### PR TITLE
Reduce map accesses and optimise temp file determinations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/inconshreveable/log15 v2.16.0+incompatible
+	github.com/klauspost/pgzip v1.2.6
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/smartystreets/goconvey v1.7.2
@@ -44,7 +45,6 @@ require (
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
-	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect

--- a/summary/basedirs/basedirs.go
+++ b/summary/basedirs/basedirs.go
@@ -268,7 +268,7 @@ func NewBaseDirs(output outputForDir, db output) summary.OperationGenerator { //
 }
 
 // Add is a summary.Operation method.
-func (b *baseDirs) Add(info *summary.FileInfo) error {
+func (b *baseDirs) Add(info *summary.FileInfo) error { //nolint:gocyclo
 	if b.thisDir == nil {
 		b.thisDir = info.Path
 		b.isTempDir = b.parent != nil && b.parent.isTempDir ||

--- a/summary/dirguta/dirguta.go
+++ b/summary/dirguta/dirguta.go
@@ -146,12 +146,7 @@ func newDirGroupUserTypeAge(db DB, refTime int64) summary.OperationGenerator {
 func (d *DirGroupUserTypeAge) Add(info *summary.FileInfo) error {
 	if d.thisDir == nil {
 		d.thisDir = info.Path
-
-		if d.parent != nil && d.parent.isTempDir {
-			d.isTempDir = true
-		} else {
-			d.isTempDir = IsTemp(info.Name)
-		}
+		d.isTempDir = d.parent != nil && d.parent.isTempDir || IsTemp(info.Name)
 	}
 
 	if info.IsDir() && info.Path != nil && info.Path.Parent == d.thisDir {

--- a/summary/dirguta/dirguta.go
+++ b/summary/dirguta/dirguta.go
@@ -143,7 +143,7 @@ func newDirGroupUserTypeAge(db DB, refTime int64) summary.OperationGenerator {
 // filetypes, so if you sum all the filetypes to get information about a given
 // directory+group+user combination, you should ignore "temp". Only count "temp"
 // when it's the only type you're considering, or you'll count some files twice.
-func (d *DirGroupUserTypeAge) Add(info *summary.FileInfo) error {
+func (d *DirGroupUserTypeAge) Add(info *summary.FileInfo) error { //nolint:funlen,gocyclo,cyclop
 	if d.thisDir == nil {
 		d.thisDir = info.Path
 		d.isTempDir = d.parent != nil && d.parent.isTempDir || IsTemp(info.Name)
@@ -157,26 +157,21 @@ func (d *DirGroupUserTypeAge) Add(info *summary.FileInfo) error {
 		return nil
 	}
 
+	gutaKeysA := gutaKeyPool.Get().(*[maxNumOfGUTAKeys]gutaKey) //nolint:errcheck,forcetypeassert
+	gKeys := gutaKeys(gutaKeysA[:0])
 	atime := info.ATime
 
 	if info.IsDir() {
 		atime = d.now
 	}
 
-	gutaKeysA := gutaKeyPool.Get().(*[maxNumOfGUTAKeys]gutaKey) //nolint:errcheck,forcetypeassert
-	gKeys := gutaKeys(gutaKeysA[:0])
+	gKeys.append(info.GID, info.UID, FilenameToType(info.Name))
 
-	filetype := FilenameToType(info.Name)
-	isTmp := d.isTempDir || IsTemp(info.Name)
-
-	gKeys.append(info.GID, info.UID, filetype)
-
-	if isTmp {
+	if d.isTempDir || IsTemp(info.Name) {
 		gKeys.append(info.GID, info.UID, db.DGUTAFileTypeTemp)
 	}
 
 	d.addForEach(gKeys, info.Size, atime, maxInt(0, info.MTime))
-
 	gutaKeyPool.Put(gutaKeysA)
 
 	return nil
@@ -329,7 +324,7 @@ func (d *DirGroupUserTypeAge) Output() error {
 		return err
 	}
 
-	if d.parent == nil {
+	if d.parent == nil { //nolint:nestif
 		if err := d.outputRoot(dguta); err != nil {
 			return err
 		}

--- a/summary/dirguta/filetypes.go
+++ b/summary/dirguta/filetypes.go
@@ -28,7 +28,6 @@ package dirguta
 
 import (
 	"github.com/wtsi-hgi/wrstat-ui/db"
-	"github.com/wtsi-hgi/wrstat-ui/summary"
 )
 
 type chars [256]uint8
@@ -534,8 +533,8 @@ var tmpPrefixes = [...]state{ //nolint:gochecknoglobals
 	{ // 0
 		chars: chars{
 			'.': 1,
-			'T': 2,
-			't': 2,
+			'T': 7,
+			't': 7,
 		},
 	},
 	{ // 1: "."
@@ -544,7 +543,7 @@ var tmpPrefixes = [...]state{ //nolint:gochecknoglobals
 			't': 2,
 		},
 	},
-	{ // 2: ".t", "t"
+	{ // 2: ".t"
 		chars: chars{
 			'E': 3,
 			'e': 3,
@@ -552,60 +551,51 @@ var tmpPrefixes = [...]state{ //nolint:gochecknoglobals
 			'm': 4,
 		},
 	},
-	{ // 3: ".te", "te"
+	{ // 3: ".te"
 		chars: chars{
 			'M': 4,
 			'm': 4,
 		},
 	},
-	{ // 4: ".tem", ".tm", "tem", "tm"
+	{ // 4: ".tem", ".tm"
 		chars: chars{
 			'P': 5,
 			'p': 5,
 		},
 	},
-	{ // 5: ".temp", ".tmp", "temp", "tmp"
+	{ // 5: ".temp", ".tmp"
 		chars: chars{
 			'.': 6,
 		},
 	},
-	{ // 6: ".temp.", ".tmp.", "temp.", "tmp."
+	{ // 6: ".temp.", ".tmp.", "temp.", "tmp.", "temp/", "tmp/"
 		typ: db.DGUTAFileTypeTemp,
 	},
-}
-
-var tmpPaths = [...]state{ //nolint:gochecknoglobals
-	{ // 0
+	{ // 7: "t"
 		chars: chars{
-			'T': 1,
-			't': 1,
+			'E': 8,
+			'e': 8,
+			'M': 9,
+			'm': 9,
 		},
 	},
-	{ // 1: "t"
+	{ // 8: "te"
 		chars: chars{
-			'E': 2,
-			'e': 2,
-			'M': 3,
-			'm': 3,
+			'M': 9,
+			'm': 9,
 		},
 	},
-	{ // 2: "te"
+	{ // 9: "tem", "tm"
 		chars: chars{
-			'M': 3,
-			'm': 3,
+			'P': 10,
+			'p': 10,
 		},
 	},
-	{ // 3: "tem", "tm"
+	{ // 10: "temp", "tmp"
 		chars: chars{
-			'P': 4,
-			'p': 4,
+			'.': 6,
+			'/': 6,
 		},
-	},
-	{ // 4: "temp", "tmp"
-		chars: fillChars(5),
-		typ:   db.DGUTAFileTypeTemp,
-	},
-	{ // 5: OTHER
 	},
 }
 
@@ -646,22 +636,9 @@ var tmpSuffixes = [...]state{ //nolint:gochecknoglobals
 	},
 }
 
-func fillChars(id uint8) chars {
-	var c chars
-
-	for n := range c {
-		c[n] = id
-	}
-
-	return c
-}
-
-// filenameToType determines the filetype of the given path based on its
-// basename, and returns a slice of our DirGUTAFileType. More than one is
-// possible, because a path can be both a temporary file, and another type.
-func filenameToType(name string) (db.DirGUTAFileType, bool) {
-	isTmp := isTempFile(name)
-
+// FilenameToType determines the filetype of the given path based on its
+// basename, and returns a a DirGUTAFileType.
+func FilenameToType(name []byte) db.DirGUTAFileType {
 	var place uint8
 
 	for len(name) > 0 {
@@ -674,47 +651,30 @@ func filenameToType(name string) (db.DirGUTAFileType, bool) {
 		place = next
 	}
 
-	return filenameSuffixes[place].typ, isTmp
+	return filenameSuffixes[place].typ
 }
 
-// isTempFile tells you if path is named like a temporary file.
-func isTempFile(name string) bool {
+// IsTemp tells you if path is named like a temporary file.
+func IsTemp(name []byte) bool {
 	return hasTempPrefix(name) || hasTempSuffix(name)
 }
 
-func hasTempPrefix(name string) bool {
+func hasTempPrefix(name []byte) bool {
 	var place uint8
 
-	for len(name) > 0 {
-		next := tmpPrefixes[place].chars[name[0]]
+	for _, b := range name {
+		next := tmpPrefixes[place].chars[b]
 		if next == 0 {
 			break
 		}
 
-		name = name[1:]
 		place = next
 	}
 
 	return tmpPrefixes[place].typ == db.DGUTAFileTypeTemp
 }
 
-func isTemp(name string) bool {
-	var place uint8
-
-	for len(name) > 0 {
-		next := tmpPaths[place].chars[name[0]]
-		if next == 0 {
-			break
-		}
-
-		name = name[1:]
-		place = next
-	}
-
-	return tmpPaths[place].typ == db.DGUTAFileTypeTemp
-}
-
-func hasTempSuffix(name string) bool {
+func hasTempSuffix(name []byte) bool {
 	var place uint8
 
 	for len(name) > 0 {
@@ -728,21 +688,4 @@ func hasTempSuffix(name string) bool {
 	}
 
 	return tmpSuffixes[place].typ == db.DGUTAFileTypeTemp
-}
-
-func isTempDir(path *summary.DirectoryPath) bool {
-	for path != nil {
-		name := path.Name
-		if name[len(name)-1] == '/' {
-			name = name[:len(name)-1]
-		}
-
-		if hasTempPrefix(name) || isTemp(name) || hasTempSuffix(name) {
-			return true
-		}
-
-		path = path.Parent
-	}
-
-	return false
 }

--- a/summary/dirguta/filetypes.go
+++ b/summary/dirguta/filetypes.go
@@ -602,36 +602,43 @@ var tmpPrefixes = [...]state{ //nolint:gochecknoglobals
 var tmpSuffixes = [...]state{ //nolint:gochecknoglobals
 	{ // 0
 		chars: chars{
-			'P': 1,
-			'p': 1,
+			'/': 1,
+			'P': 2,
+			'p': 2,
 		},
 	},
-	{ // 1: "p"
+	{ // 1: "/"
 		chars: chars{
-			'M': 2,
-			'm': 2,
+			'P': 2,
+			'p': 2,
 		},
 	},
-	{ // 2: "mp"
+	{ // 2: "p", "p/"
 		chars: chars{
-			'E': 3,
-			'e': 3,
-			'T': 4,
-			't': 4,
+			'M': 3,
+			'm': 3,
 		},
 	},
-	{ // 3: "emp"
+	{ // 3: "mp", "mp/"
 		chars: chars{
-			'T': 4,
-			't': 4,
+			'E': 4,
+			'e': 4,
+			'T': 5,
+			't': 5,
 		},
 	},
-	{ // 4: "temp", "tmp"
+	{ // 4: "emp", "emp/"
 		chars: chars{
-			'.': 5,
+			'T': 5,
+			't': 5,
 		},
 	},
-	{ // 5: ".temp", ".tmp"
+	{ // 5: "temp", "temp/", "tmp", "tmp/"
+		chars: chars{
+			'.': 6,
+		},
+	},
+	{ // 6: ".temp", ".temp/", ".tmp", ".tmp/"
 		typ: db.DGUTAFileTypeTemp,
 	},
 }

--- a/summary/dirguta/filetypes.go
+++ b/summary/dirguta/filetypes.go
@@ -637,7 +637,7 @@ var tmpSuffixes = [...]state{ //nolint:gochecknoglobals
 }
 
 // FilenameToType determines the filetype of the given path based on its
-// basename, and returns a a DirGUTAFileType.
+// basename, and returns a DirGUTAFileType.
 func FilenameToType(name []byte) db.DirGUTAFileType {
 	var place uint8
 

--- a/summary/summary.go
+++ b/summary/summary.go
@@ -54,7 +54,7 @@ type SummaryWithTimes struct { //nolint:revive
 	Mtime int64 // seconds since Unix epoch
 }
 
-// add will increment our count and add the given size to our size. It also
+// Add will increment our count and add the given size to our size. It also
 // stores the given atime if it is older than our current one, and the given
 // mtime if it is newer than our current one.
 func (s *SummaryWithTimes) Add(size int64, atime int64, mtime int64) {
@@ -66,6 +66,21 @@ func (s *SummaryWithTimes) Add(size int64, atime int64, mtime int64) {
 
 	if mtime > 0 && (s.Mtime == 0 || mtime > s.Mtime) {
 		s.Mtime = mtime
+	}
+}
+
+// AddSummary add the data in the passed SummaryWithTimes to the existing
+// SummaryWithTimes.
+func (s *SummaryWithTimes) AddSummary(t *SummaryWithTimes) {
+	s.Count += t.Count
+	s.Size += t.Size
+
+	if t.Atime > 0 && (s.Atime == 0 || t.Atime < s.Atime) {
+		s.Atime = t.Atime
+	}
+
+	if t.Mtime > 0 && (s.Mtime == 0 || t.Mtime > s.Mtime) {
+		s.Mtime = t.Mtime
 	}
 }
 


### PR DESCRIPTION
Store whether each directory (or one it's parents) is classed as a temporary to avoid having to re-check each the parents of each entry multiple times.

Also only add a childs dirguta information once it's complete, so it can all be added at once instead of adding each file indiviudally, having to do filetype determination multiple times for each entry and having to do more map acceses.