### PR TITLE
Make sure dirs are processeed as dirs

### DIFF
--- a/stats/stats.go
+++ b/stats/stats.go
@@ -41,7 +41,7 @@ const (
 	CharType    = 'c'
 )
 
-var slash = []byte{'/'}
+var slash = []byte{'/'} //nolint:gochecknoglobals
 
 // Error is the type of the constant Err* variables.
 type Error string

--- a/stats/stats_test.go
+++ b/stats/stats_test.go
@@ -104,7 +104,7 @@ func TestParseStats(t *testing.T) {
 		})
 
 		Convey("Directories marked as file will be typed as a directory", func() {
-			io.Copy(&sb, f)
+			io.Copy(&sb, f) //nolint:errcheck
 
 			p = NewStatsParser(strings.NewReader(strings.ReplaceAll(sb.String(), "\td\t", "\tf\t")))
 


### PR DESCRIPTION
There seems to be a lustre bug (?) that sometimes returns an empty stat_t for directories, and an empty mode will be treated as a file.

As we know whether a path is a directory or a file, we can correct this for dirs.

This is also fixed in `wrstat`, but this will work for older log files.