### PR TITLE
HSW-175 Update footer to display dynamic year

### DIFF
--- a/server/static/wrstat/src/App.tsx
+++ b/server/static/wrstat/src/App.tsx
@@ -283,7 +283,7 @@ const groupNameToIDMap = new Map<string, number>(),
 						}} />
 				</details>
 			}
-			<div id="copyright">&copy; 2023 Genome Research Ltd.</div>
+			<div id="copyright">&copy; {new Date().getFullYear()} Genome Research Ltd.</div>
 		</>;
 	};
 


### PR DESCRIPTION
Currently, the footer displays a hardcoded year (2023). This should be updated to use the current year dynamically, so it always stays accurate without manual changes.

